### PR TITLE
Release 1.2.3

### DIFF
--- a/Mission_Owner_SCCA_(SCCAv1)/RELEASE.md
+++ b/Mission_Owner_SCCA_(SCCAv1)/RELEASE.md
@@ -32,6 +32,9 @@
 - Supported ONSR OCI Region(OCI-6 and OCI-11)
 - Updated Terraform Version to atleast 1.5 .
 
+## v1.2.3 - 11/18/2025
+- Removed 3rd party module tqdm from **destroy_lz.py** destroy script
+
 
 ## License
 

--- a/Mission_Owner_SCCA_(SCCAv1)/destroy_lz.py
+++ b/Mission_Owner_SCCA_(SCCAv1)/destroy_lz.py
@@ -9,8 +9,6 @@ from datetime import datetime
 from typing import Dict, List
 
 import oci
-from tqdm import tqdm
-
 
 class DestroyLandingZone:
     def __init__(self, parent_cmp: str, region_key: str, resource_label: str, oci_config: str = "~/.oci/config", profile_name: str = "DEFAULT"):
@@ -180,7 +178,7 @@ class DestroyLandingZone:
                 break
             bucket_files += list_files.data.objects
 
-        for filenames in tqdm(bucket_files, desc=f'bucket {bucket_name}'):
+        for filenames in bucket_files:
             self.os_client.delete_object(
                 self.os_namespace,
                 bucket_name,


### PR DESCRIPTION
## v1.2.3 - 11/18/2025
- Removed 3rd party module tqdm from **destroy_lz.py** destroy script
