### PR TITLE
Changed SCCAv1 Workload Compartment Naming Syntax.

### DIFF
--- a/Mission_Owner_SCCA_(SCCAv1)/CONFIGURATION-GUIDE.md
+++ b/Mission_Owner_SCCA_(SCCAv1)/CONFIGURATION-GUIDE.md
@@ -40,10 +40,10 @@ This is the basic information Terraform needs to connect to OCI. If you deploy t
 * [api_fingerprint](VARIABLES.md#input_api_fingerprint) - Fingerprint string for user's API Key. 
 * [api_private_key_path](VARIABLES.md#input_api_private_key_path) - Path to user's private API key file.
 
-### Other needed configurations 
+### Other needed configurations
 
-* [mission_owner_key](VARIABLES.md#input_mission_owner_key) - A short string (3-4 char) appended to Workload resource names to help distinguish them.
-* [workload_name](VARIABLES.md#input_workload_name) - A name for the sample workload. Each workload in the LZ should have a unique name.
+* [workload_postfix](VARIABLES.md#input_mission_owner_key) - A string used to allow multiple workload stacks to coexist without duplicate literals or naming collisions.
+* [wrk_compartment_name_prefix](VARIABLES.md#input_workload_name) - A name for the sample workload. Each workload in the LZ should have a unique name.
 * [resource_label](VARIABLES.md#input_resource_label) - Some resources, such as policies and CloudGuard configurations, need to be deployed globally to the tenancy. This is a short (3-4 char) string appended to resource names to distinguish them in case more than one Landing Zone is deployed. This should be unique per tenancy. 
 * [bastion_client_cidr_block_allow_list](VARIABLES.md#input_bastion_client_cidr_block_allow_list) - A list of strings, describing CIDR blocks allowed to connect to the Bastion deployed in the sample Workload network. 
 * [home_region_deployment](VARIABLES.md#input_home_region_deployment) - A boolean to indicate whether the current stack deployment is to the home region or a non-home region.
@@ -117,7 +117,7 @@ Alarms are initially deployed in a `disabled` state, and can be enabled as desir
 
 Announcements are events sent by Oracle concerning things such as planned maintinance and outages that may impact the operation of OCI services.
 
-### Notifications 
+### Notifications
 
 Notifications allow events, such as Alarm triggers or Announcements, to be sent to a list of recipients via email. Sets of events are directed to a topic and a list of email address (called endpoints) is subscribed to that topic. Each email address will receive an email with a link to activate their subscription.  
 

--- a/Mission_Owner_SCCA_(SCCAv1)/examples/terraform.tfvars.example
+++ b/Mission_Owner_SCCA_(SCCAv1)/examples/terraform.tfvars.example
@@ -45,8 +45,8 @@ firewall_subnet_cidr_block = "192.168.0.0/25"
 lb_subnet_cidr_block       = "192.168.0.128/25"
 
 # WORKLOAD
-mission_owner_key             = ""
-workload_name                 = ""
+workload_postfix              = ""
+wrk_compartment_name_prefix   = ""
 workload_vcn_cidr_block       = "192.168.2.0/24"
 workload_subnet_cidr_block    = "192.168.2.0/24"
 workload_db_vcn_cidr_block    = "192.168.3.0/24"

--- a/Mission_Owner_SCCA_(SCCAv1)/iam.tf
+++ b/Mission_Owner_SCCA_(SCCAv1)/iam.tf
@@ -175,7 +175,7 @@ locals {
     name        = "OCI-SCCA-LZ-Workload-Policy"
     description = "This account is required for the management of the Mission Application workloads."
     statements = [
-      "Allow group ${local.identity_domain.domain_display_name}/WorkloadAdmin to manage all-resources in compartment OCI-SCCA-LZ-${var.workload_name}-${var.mission_owner_key}",
+      "Allow group ${local.identity_domain.domain_display_name}/WorkloadAdmin to manage all-resources in compartment ${var.wrk_compartment_name_prefix}-${local.region_key[0]}-${var.workload_postfix}",
       "Allow group ${local.identity_domain.domain_display_name}/WorkloadAdmin to use key-delegate in compartment ${var.vdms_compartment_name}-${local.region_key[0]}-${var.resource_label} where target.key.id = ${module.master_encryption_key.key_ocid}"
     ]
   }

--- a/Mission_Owner_SCCA_(SCCAv1)/schema.yaml
+++ b/Mission_Owner_SCCA_(SCCAv1)/schema.yaml
@@ -82,8 +82,8 @@ variableGroups:
   - title: Workload Variables
     visible: true
     variables:
-      - mission_owner_key
-      - workload_name
+      - workload_postfix
+      - wrk_compartment_name_prefix
       - workload_vcn_cidr_block
       - workload_subnet_cidr_block
       - workload_db_vcn_cidr_block
@@ -427,14 +427,14 @@ variables:
     pattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1][0-9]|[2][0-9]))$
 
   #Workload Variables
-  mission_owner_key:
-    type: string
-    required: true
-    description: "Short prefix added to workload name to group workload resources."
-  workload_name:
+  workload_postfix:
     type: string
     required: true
     description: "Name for initial example workload. Each workload within a Landing Zone should have a unique name. "
+  wrk_compartment_name_prefix:
+    type: string
+    required: true
+    description: "The name of the workload compartment by default <Compartment Name Prefix>-<Region>-<Workload-Postfix>."
   workload_vcn_cidr_block:
     type: string
     default: "192.168.2.0/24"

--- a/Mission_Owner_SCCA_(SCCAv1)/security.tf
+++ b/Mission_Owner_SCCA_(SCCAv1)/security.tf
@@ -189,7 +189,7 @@ locals {
   bastion = {
     name                                 = "OCI-SCCA-LZ-BASTION-${var.resource_label}"
     bastion_client_cidr_block_allow_list = var.bastion_client_cidr_block_allow_list
-    target_subnet_id                     = module.workload_network.subnets["OCI-SCCA-LZ-Workload-SUB-${var.workload_name}-${local.region_key[0]}"]
+    target_subnet_id                     = module.workload_network.subnets["${var.wrk_compartment_name_prefix}-SUB-${local.region_key[0]}-${var.workload_postfix}"]
   }
 }
 

--- a/Mission_Owner_SCCA_(SCCAv1)/workload-variables.tf
+++ b/Mission_Owner_SCCA_(SCCAv1)/workload-variables.tf
@@ -3,14 +3,16 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl. #
 # ###################################################################################################### #
 
-variable "mission_owner_key" {
+variable "workload_postfix" {
   type        = string
-  description = ""
+  description = "Atleast 4 Alphanumeric Charater to Describe the Workload : WRK1"
+  default     = "SWR1"
 }
 
-variable "workload_name" {
+variable "wrk_compartment_name_prefix" {
   type        = string
-  description = "The name of workload stack"
+  description = "The name of the workload compartment by default <Workload Compartment name Prefix>-<Region>-<Workload-Postfix>."
+  default     = "OCI-SCCA-LZ-WRK"
 }
 
 variable "workload_vcn_cidr_block" {

--- a/Mission_Owner_SCCA_(SCCAv1)/workload.tf
+++ b/Mission_Owner_SCCA_(SCCAv1)/workload.tf
@@ -5,18 +5,18 @@
 
 locals {
   workload_compartment = {
-    name        = "OCI-SCCA-LZ-${var.workload_name}-${var.mission_owner_key}"
+    name        = "${var.wrk_compartment_name_prefix}-${local.region_key[0]}-${var.workload_postfix}"
     description = "Workload Compartment"
   }
 
   workload_network = {
-    name                     = "OCI-SCCA-LZ-Workload-VCN-${var.workload_name}-${local.region_key[0]}"
+    name                     = "${var.wrk_compartment_name_prefix}-VCN-${local.region_key[0]}-${var.workload_postfix}"
     vcn_dns_label            = "workloadvcn"
     lockdown_default_seclist = false
     subnet_map = {
       OCI-SCCA-LZ-Workload-SUB = {
-        name                       = "OCI-SCCA-LZ-Workload-SUB-${var.workload_name}-${local.region_key[0]}"
-        description                = "Workload ${var.workload_name} Subnet"
+        name                       = "${var.wrk_compartment_name_prefix}-SUB-${local.region_key[0]}-${var.workload_postfix}"
+        description                = "Workload ${var.wrk_compartment_name_prefix} VCN Subnet"
         dns_label                  = "workloadsubnet"
         cidr_block                 = var.workload_subnet_cidr_block
         prohibit_public_ip_on_vnic = true
@@ -25,13 +25,13 @@ locals {
   }
 
   workload_db_network = {
-    name                     = "OCI-SCCA-LZ-Workload-DB-VCN-${var.workload_name}-${local.region_key[0]}"
+    name                     = "${var.wrk_compartment_name_prefix}-DB-VCN-${local.region_key[0]}-${var.workload_postfix}"
     vcn_dns_label            = "workloaddbvcn"
     lockdown_default_seclist = false
     subnet_map = {
       OCI-SCCA-LZ-Workload-DB-SUB = {
-        name                       = "OCI-SCCA-LZ-Workload-DB-SUB-${var.workload_name}-${local.region_key[0]}"
-        description                = "Workload ${var.workload_name} Subnet"
+        name                       = "${var.wrk_compartment_name_prefix}-DB-SUB-${local.region_key[0]}-${var.workload_postfix}"
+        description                = "Workload ${var.wrk_compartment_name_prefix} VCN DB Subnet"
         dns_label                  = "dbsubnet" # workloaddbsubnet is too long (not 15 chars)
         cidr_block                 = var.workload_db_subnet_cidr_block
         prohibit_public_ip_on_vnic = true
@@ -41,7 +41,7 @@ locals {
 
   workload_route_table = {
     Workload-VCN-Egress = {
-      route_table_display_name = "Workload-${var.workload_name}-VCN-Egress"
+      route_table_display_name = "${var.wrk_compartment_name_prefix}-RT-${local.region_key[0]}-${var.workload_postfix}"
       subnet_id                = module.workload_network.subnets[local.workload_network.subnet_map["OCI-SCCA-LZ-Workload-SUB"].name]
       subnet_name              = "OCI-SCCA-LZ-Workload-SUB"
       route_rules = {
@@ -71,7 +71,7 @@ locals {
 
   workload_db_route_table = {
     Workload-DB-VCN-Egress = {
-      route_table_display_name = "Workload-${var.workload_name}-DB-VCN-Egress"
+      route_table_display_name = "${var.wrk_compartment_name_prefix}-DB-RT-${local.region_key[0]}-${var.workload_postfix}"
       subnet_id                = module.workload_db_network.subnets[local.workload_db_network.subnet_map["OCI-SCCA-LZ-Workload-DB-SUB"].name]
       subnet_name              = "OCI-SCCA-LZ-Workload-DB-SUB"
       route_rules = {
@@ -100,12 +100,12 @@ locals {
   }
 
   workload_load_balancer = {
-    lb_name   = "OCI-SCCA-LZ-Workload-LB-${var.workload_name}-${local.region_key[0]}"
+    lb_name   = "${var.wrk_compartment_name_prefix}-WRK-LB-${local.region_key[0]}-${var.workload_postfix}"
     lb_subnet = module.workload_network.subnets[local.workload_network.subnet_map["OCI-SCCA-LZ-Workload-SUB"].name]
   }
 
   workload_vtap = {
-    vtap_display_name           = "OCI-SCCA-LZ-WORKLOAD-VTAP-${local.region_key[0]}"
+    vtap_display_name           = "${var.wrk_compartment_name_prefix}-WRK-VTAP-${local.region_key[0]}-${var.workload_postfix}"
     vtap_source_type            = "LOAD_BALANCER"
     capture_filter_display_name = "WORKLOAD-VTAP-Capture-Filter"
     vtap_capture_filter_rules = {


### PR DESCRIPTION
- Issue Statement
    Update the SCCAv1 workload Terraform modules to use a consistent, parameterized naming convention for all workload resources so deployments no longer
    mix legacy WRK prefixes with the OCI-SCCA-LZ-WRK defaults.

- Background
The current defaults in Mission_Owner_SCCA_(SCCAv1)/workload.tf hardcode the compartment name to OCI-SCCA-LZ-${var.workload_name}-${var.mission_owner_key}, preventing customers from supplying organization-specific prefixes and making inventory searches and automation filters harder to manage.

- Proposed Change
-	Introduce a shared workload naming pattern ${var.wrk_compartment_name_prefix}-${local.region_key[0]}-${var.workload_postfix} applied across workload compartments, networking assets, identity groups, and policies.
-	Add a required wrk_compartment_name_prefix input (length and character validation) that defaults to OCI-SCCA-LZ-WRK, allowing customers to override the prefix when desired.
-	Add a workload_postfix variable so multiple workload stacks can coexist without duplicate literals or naming collisions.

- Acceptance Criteria
-	Unit and integration tests (or equivalent validation scripts) confirm the updated names across all workload resources.
-	Documentation and release notes include backward-compatibility guidance.

- Out of Scope
   - SCCAv1 Resources outside the workload templates (for example, VDSS or VDMS components) remains unchanged.
